### PR TITLE
Fix TFAR 1.0 compatability

### DIFF
--- a/addons/zade_boc/functions/utility/fn_pasteRadioSettings.sqf
+++ b/addons/zade_boc/functions/utility/fn_pasteRadioSettings.sqf
@@ -17,8 +17,14 @@
 params ["_player","_settings"];
 
 //only if TFAR is loaded
+
 if (isClass(configFile >> "cfgPatches" >> "task_force_radio")) exitWith {
      //apply settings
      private _radio = _player call TFAR_fnc_backpackLr;
-     [_radio select 0, _radio select 1, _settings] call TFAR_fnc_setLrSettings;
+     //Changed API in TFAR 1.0
+     if (isClass(configFile >> "cfgPatches" >> "tfar_core")) {
+         [_radio, _settings] call TFAR_fnc_setLrSettings;     
+     } else {
+         [_radio select 0, _radio select 1, _settings] call TFAR_fnc_setLrSettings;
+     }
 };

--- a/addons/zade_boc/functions/utility/fn_pasteRadioSettings.sqf
+++ b/addons/zade_boc/functions/utility/fn_pasteRadioSettings.sqf
@@ -22,9 +22,9 @@ if (isClass(configFile >> "cfgPatches" >> "task_force_radio")) exitWith {
      //apply settings
      private _radio = _player call TFAR_fnc_backpackLr;
      //Changed API in TFAR 1.0
-     if (isClass(configFile >> "cfgPatches" >> "tfar_core")) {
+     if (isClass(configFile >> "cfgPatches" >> "tfar_core")) then {
          [_radio, _settings] call TFAR_fnc_setLrSettings;     
      } else {
          [_radio select 0, _radio select 1, _settings] call TFAR_fnc_setLrSettings;
-     }
+     };
 };


### PR DESCRIPTION
https://github.com/michail-nikolaev/task-force-arma-3-radio/blob/1.0/addons/core/functions/fnc_setLrSettings.sqf API changed in 1.0.

Also this add's only compatability for TFAR and every other Mod that stores Variables on the Players Backpack will still be broken.
So consider using https://github.com/michail-nikolaev/task-force-arma-3-radio/blob/1.0/addons/core/functions/events/fnc_onArsenal.sqf instead and save all Variables on the Backpack instead of just some.