### PR TITLE
Hotfix for backpack duplicating and item disappearing

### DIFF
--- a/addons/zade_boc/functions/utility/fn_actionOnChest.sqf
+++ b/addons/zade_boc/functions/utility/fn_actionOnChest.sqf
@@ -16,7 +16,7 @@
 params ["_player"];
 
 private _backpack = backpack _player;
-private _backpackitems = (itemCargo (backpackContainer _player) + weaponCargo (backpackContainer _player) + backpackCargo (backpackContainer _player));
+private _backpackitems = backpackItems _player;
 private _backpackmags = [_player] call zade_boc_fnc_backpackMagazines;
 
 //make sure the player has no chestpack and a backpack
@@ -39,7 +39,7 @@ if ((_backpack isEqualTo "") or !(([_player] call zade_boc_fnc_chestpack) isEqua
      _backpackitems pushBack (_x select 1);
      _backpackitems pushBack (_x select 2);
      _backpackitems pushBack (_x select 3);
-     _backpackitems pushBack (_x select 5);
+     _backpackitems pushBack (_x select 6);
 
      //add magazine
      if !((_x select 4) isEqualTo []) then {


### PR DESCRIPTION
- Fixes item deletion for certain ammo types
- Fixes backpack duping (I believe).
- Fixes #42 
- Should be integrated alongside the secondary mag handling introduced in PR #43.
- Hotfix until the long-awaited rework.